### PR TITLE
MON-3289: github action to update downstream version in CMO

### DIFF
--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -1,0 +1,21 @@
+name: Update Version
+
+on: [delete]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Get token to trigger update version workflow
+        id: update-version
+        uses: getsentry/action-github-app-token@v1
+        with:
+          app_id: ${{ secrets.UPDATE_VERSION_APP_ID }}
+          private_key: ${{ secrets.UPDATE_VERSION_APP_PRIVATE_KEY }}
+          scope: ${{ github.repository_owner }}
+      - name: Trigger update version workflow
+        run: |
+         curl -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ steps.update-version.outputs.token }}" \
+            --request POST \
+            https://api.github.com/repos/${{ github.repository_owner }}/syncbot/actions/workflows/update-cmo-deps-versions.yaml/dispatches -d '{"ref":"main"}'


### PR DESCRIPTION
This commit adds a github action listener for branch delete event which
happens when upstream -> downstream PR is merged with openshift repos.
Once the event occurs, newly added action invokes rhobs/syncbot workflow
 which creates PR to bump the version.yaml.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

